### PR TITLE
deltachat bridge: send images with ViewType.IMAGE for compression

### DIFF
--- a/scripts/deltachat_bridge.py
+++ b/scripts/deltachat_bridge.py
@@ -16,7 +16,10 @@ from typing import Any
 
 import websockets
 from deltachat_rpc_client import DeltaChat, EventType, Rpc, SpecialContactId
+from deltachat_rpc_client.const import ViewType
 from websockets.exceptions import ConnectionClosed
+
+_IMAGE_EXTENSIONS = frozenset((".png", ".jpg", ".jpeg", ".gif", ".webp", ".svg", ".bmp", ".tiff"))
 
 ACCOUNTS_TOML_TEMPLATE = """accounts = []
 selected_account = 0
@@ -431,13 +434,16 @@ class DeltaChatBridge:
 
         if media_items:
             first_file = self._resolve_outbound_file(media_items[0])
+            first_vt = ViewType.IMAGE if Path(first_file).suffix.lower() in _IMAGE_EXTENSIONS else None
             if content != "":
-                chat.send_message(text=content, file=first_file)
+                chat.send_message(text=content, file=first_file, viewtype=first_vt)
             else:
-                chat.send_file(first_file)
+                chat.send_message(file=first_file, viewtype=first_vt) if first_vt else chat.send_file(first_file)
 
             for extra_file in media_items[1:]:
-                chat.send_file(self._resolve_outbound_file(extra_file))
+                resolved = self._resolve_outbound_file(extra_file)
+                vt = ViewType.IMAGE if Path(resolved).suffix.lower() in _IMAGE_EXTENSIONS else None
+                chat.send_message(file=resolved, viewtype=vt) if vt else chat.send_file(resolved)
             return
 
         if content != "":


### PR DESCRIPTION
When sending image files (`.png`, `.jpg`, `.gif`, etc.) via DeltaChat, set `viewtype=ViewType.IMAGE` so the client compresses them before sending.

Previously all media was sent as generic files via `chat.send_file()`, resulting in full-resolution transfers. Now image extensions are detected and sent with `ViewType.IMAGE`, which lets DeltaChat apply its built-in image compression.

**Tested:** 1920×1080 1.6MB image compressed to 512KB on delivery.

Non-image files (PDFs, etc.) continue to be sent as `send_file()` unchanged.