### PR TITLE
feat(tools): add compact tool for manual context compaction

### DIFF
--- a/pkg/agent/loop.go
+++ b/pkg/agent/loop.go
@@ -680,7 +680,9 @@ func (al *AgentLoop) maybeSummarize(sessionKey string) {
 // This is called by the compact tool when the agent requests context compaction.
 // keepLast specifies how many recent messages to preserve (0 = summarize all in hard mode).
 func (al *AgentLoop) CompactSession(sessionKey string, mode tools.CompactMode, keepLast int) (string, error) {
-	if keepLast <= 0 && mode == tools.CompactModeSoft {
+	if mode == tools.CompactModeHard {
+		keepLast = 0
+	} else if keepLast <= 0 {
 		keepLast = 4
 	}
 	result := al.doCompaction(sessionKey, keepLast)

--- a/pkg/tools/compact.go
+++ b/pkg/tools/compact.go
@@ -82,12 +82,7 @@ func (t *CompactTool) Execute(ctx context.Context, args map[string]interface{}) 
 		keepLast = 0
 	}
 	if keepLast > 50 {
-		keepLast = 50 // Sanity limit
-	}
-
-	// In hard mode, always keep 0
-	if mode == CompactModeHard {
-		keepLast = 0
+		keepLast = 50
 	}
 
 	// Get session key from execution context

--- a/pkg/tools/compact_test.go
+++ b/pkg/tools/compact_test.go
@@ -90,9 +90,11 @@ func TestCompactTool_SoftMode(t *testing.T) {
 }
 
 func TestCompactTool_HardMode(t *testing.T) {
+	var capturedMode CompactMode
 	var capturedKeepLast int
 
 	callback := func(sessionKey string, mode CompactMode, keepLast int) (string, error) {
+		capturedMode = mode
 		capturedKeepLast = keepLast
 		return "Test summary", nil
 	}
@@ -108,8 +110,11 @@ func TestCompactTool_HardMode(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if capturedKeepLast != 0 {
-		t.Errorf("hard mode should force keepLast to 0, got: %d", capturedKeepLast)
+	if capturedMode != CompactModeHard {
+		t.Errorf("expected hard mode, got: %s", capturedMode)
+	}
+	if capturedKeepLast != 10 {
+		t.Errorf("tool should pass original keepLast to callback (mode logic handled by CompactSession), got: %d", capturedKeepLast)
 	}
 }
 


### PR DESCRIPTION
Implements #1 — adds a `compact` tool that lets the agent explicitly trigger context compaction.

## What's Done

- **Tool interface** (`pkg/tools/compact.go`):
  - `compact` tool with `mode` (soft/hard) and `keep_last` parameters
  - Soft mode: keeps last N messages (default 4) for continuity
  - Hard mode: summarizes everything, true fresh start
  - Uses existing `getExecutionContext()` to determine session key

## What's Still Needed

This PR is a **work in progress**. The following integration work is required:

1. **AgentLoop wrapper method** — Add a method to `pkg/agent/loop.go`:
   ```go
   func (al *AgentLoop) CompactSession(sessionKey string, keepLast int) (string, error) {
       // Call summarizeSession with configurable retention
       // Return the summary
   }
   ```

2. **Modify summarizeSession** — Currently hardcodes `keepLast = 4`. Needs to accept it as a parameter.

3. **Wire up the callback** — In loop.go, create and register the compact tool with a callback:
   ```go
   compactCallback := func(sessionKey string, mode tools.CompactMode, keepLast int) (string, error) {
       if mode == tools.CompactModeHard {
           keepLast = 0
       }
       return al.CompactSession(sessionKey, keepLast)
   }
   registry.Register(tools.NewCompactTool(compactCallback))
   ```

4. **Add to RegisterCoreTools** or register separately in the main agent setup.

## Usage (once integrated)

```
# Soft compact - keep last 4 messages
compact({mode: "soft"})

# Soft compact - keep last 10 messages  
compact({mode: "soft", keep_last: 10})

# Hard compact - summarize everything
compact({mode: "hard"})
```

---

Co-authored-by: Subagent <subagent@picoclaw>