### PR TITLE
fix(tools): avoid exec guard false positives on relative paths

### DIFF
--- a/pkg/tools/shell.go
+++ b/pkg/tools/shell.go
@@ -227,12 +227,45 @@ func (t *ExecTool) guardCommand(command, cwd string) string {
 			}
 		}
 
-		pathPattern := regexp.MustCompile(`[A-Za-z]:\\[^\\\"']+|/[^\s\"']+`)
-		indices := pathPattern.FindAllStringIndex(cmd, -1)
+		// NOTE: We only want to treat *actual* absolute filesystem paths as candidates.
+		// The previous implementation matched any "/..." substring anywhere in the command,
+		// which caused false positives for relative paths like "workflows/alice.json" (matched
+		// the "/alice.json" substring). We now require a boundary that indicates the path is
+		// starting (whitespace, quotes, or '='), plus a special-case for single-letter short
+		// flags like "-C/tmp".
+		absolutePathPattern := regexp.MustCompile(`(^|[\s"'=])([A-Za-z]:\\[^\s\"']+|/[^\s\"']+)`)
+		shortFlagPathPattern := regexp.MustCompile(`(^|[\s"'=])-[A-Za-z]([A-Za-z]:\\[^\s\"']+|/[^\s\"']+)`)
 
-		for _, idx := range indices {
-			raw := cmd[idx[0]:idx[1]]
-			if idx[0] == 0 {
+		type pathCandidate struct {
+			raw   string
+			start int
+		}
+
+		candidates := make([]pathCandidate, 0, 8)
+		for _, m := range absolutePathPattern.FindAllStringSubmatchIndex(cmd, -1) {
+			if len(m) < 6 {
+				continue
+			}
+			start, end := m[4], m[5]
+			if start < 0 || end < 0 || start >= end {
+				continue
+			}
+			candidates = append(candidates, pathCandidate{raw: cmd[start:end], start: start})
+		}
+		for _, m := range shortFlagPathPattern.FindAllStringSubmatchIndex(cmd, -1) {
+			if len(m) < 6 {
+				continue
+			}
+			start, end := m[4], m[5]
+			if start < 0 || end < 0 || start >= end {
+				continue
+			}
+			candidates = append(candidates, pathCandidate{raw: cmd[start:end], start: start})
+		}
+
+		for _, c := range candidates {
+			raw := c.raw
+			if c.start == 0 {
 				// Allow absolute executable paths like /bin/ls.
 				continue
 			}

--- a/pkg/tools/shell_test.go
+++ b/pkg/tools/shell_test.go
@@ -173,6 +173,26 @@ func TestGuardCommand_RestrictToWorkspace(t *testing.T) {
 		}
 	})
 
+	t.Run("relative path args with slashes allowed", func(t *testing.T) {
+		cmd := "bash skills/comfyui/bin/generate-image.sh --workflow workflows/alice.json test generated/test.png"
+		result := tool.guardCommand(cmd, dir)
+		if result != "" {
+			t.Fatalf("expected relative path args to be allowed, got: %s", result)
+		}
+	})
+
+	t.Run("absolute path outside workspace blocked", func(t *testing.T) {
+		outside := t.TempDir()
+		outsideFile := filepath.Join(outside, "file.txt")
+		result := tool.guardCommand(fmt.Sprintf("cat %q", outsideFile), dir)
+		if result == "" {
+			t.Fatalf("expected absolute path outside workspace to be blocked")
+		}
+		if !strings.Contains(strings.ToLower(result), "path outside") {
+			t.Fatalf("expected path-outside message, got %q", result)
+		}
+	})
+
 	t.Run("working_dir outside workspace", func(t *testing.T) {
 		outside := t.TempDir()
 		result := tool.guardCommand("ls -la", outside)
@@ -292,8 +312,8 @@ func TestExecTool_Execute_RestrictToWorkspaceWorkingDir(t *testing.T) {
 		}
 
 		result, err := tool.Execute(context.Background(), map[string]interface{}{
-			"command":      "pwd",
-			"working_dir":  "sub",
+			"command":         "pwd",
+			"working_dir":     "sub",
 			"timeout_seconds": 2,
 		})
 		if err != nil {


### PR DESCRIPTION
Fixes #10.

## Summary
- Tighten exec safety-guard absolute-path detection so relative args like `workflows/alice.json` don't get mis-parsed as `/alice.json`.
- Continue blocking true absolute paths that resolve outside the workspace.
- Add regression tests covering the reported repro.

## Testing
- `go test ./...`
- `go build ./...`